### PR TITLE
feat: add energy export total sensor

### DIFF
--- a/const.py
+++ b/const.py
@@ -17,6 +17,7 @@ ATTR_POWER_L3 = "power_l3"
 ATTR_POWER_TOTAL = "power_total"
 
 ATTR_ENERGY_TOTAL = "energy_total"
+ATTR_ENERGY_EXPORT_TOTAL = "energy_export_total"
 
 ATTR_ID="ItemId"
 ATTR_NAME = "Name"

--- a/perific/client.py
+++ b/perific/client.py
@@ -30,6 +30,7 @@ class ItemPacketData(BaseModel):
     huavg: Optional[List[float]] = Field(default=None, alias="huavg")
     uavg: Optional[List[float]]  = Field(default=None, alias="uavg")
     hwi: Optional[float] = Field(default=None, alias="hwi")
+    hwo: Optional[float] = Field(default=None, alias="hwo")
     # himin: Optional[List[float]] = Field(alias="himin")
     # himax: Optional[List[float]] = Field(alias="himax")
 

--- a/sensor.py
+++ b/sensor.py
@@ -33,6 +33,7 @@ from .const import (
     ATTR_CURRENT_L3,
     ATTR_POWER_TOTAL,
     ATTR_ENERGY_TOTAL,
+    ATTR_ENERGY_EXPORT_TOTAL,
     ATTR_MAC_ADDRESS,
     ATTR_CREATION_TIME,
     ATTR_ID,
@@ -191,6 +192,15 @@ SENSOR_TYPES: tuple[PerificSensorEntityDescription, ...] = (
         value_func=lambda data: safe_get(data.data, "hwi", -1),
     ),
     PerificSensorEntityDescription(
+        key=ATTR_ENERGY_EXPORT_TOTAL,
+        translation_key="energy_export_total",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=3,
+        value_func=lambda data: safe_get(data.data, "hwo", -1),
+    ),
+    PerificSensorEntityDescription(
         key=ATTR_MAC_ADDRESS,
         translation_key="mac_address",
         device_class=None,
@@ -289,6 +299,7 @@ async def async_setup_entry(
                 ATTR_POWER_L3,
                 ATTR_POWER_TOTAL,
                 ATTR_ENERGY_TOTAL,
+                ATTR_ENERGY_EXPORT_TOTAL,
                 ATTR_MAC_ADDRESS,
                 ATTR_CREATION_TIME,
                 ATTR_ID,
@@ -347,7 +358,7 @@ class PerificSensor(PerificEntity, SensorEntity):
         if not latest_data:
             return None
         try:
-            if key == ATTR_ENERGY_TOTAL:
+            if key in (ATTR_ENERGY_TOTAL, ATTR_ENERGY_EXPORT_TOTAL):
                 return self.entity_description.value_func(latest_data.phase_minute)
             return self.entity_description.value_func(latest_data.phase_real_time)
         

--- a/sensor.py
+++ b/sensor.py
@@ -198,7 +198,7 @@ SENSOR_TYPES: tuple[PerificSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         suggested_display_precision=3,
-        value_func=lambda data: safe_get(data.data, "hwo", -1),
+        value_func=lambda data: data.data.hwo if data.data.hwo is not None else -1,
     ),
     PerificSensorEntityDescription(
         key=ATTR_MAC_ADDRESS,
@@ -359,7 +359,11 @@ class PerificSensor(PerificEntity, SensorEntity):
             return None
         try:
             if key in (ATTR_ENERGY_TOTAL, ATTR_ENERGY_EXPORT_TOTAL):
+                if latest_data.phase_minute is None:
+                    return None
                 return self.entity_description.value_func(latest_data.phase_minute)
+            if latest_data.phase_real_time is None:
+                return None
             return self.entity_description.value_func(latest_data.phase_real_time)
         
         except Exception as e:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -155,7 +155,7 @@ async def test_get_latest_packets_success():
             "LatestPackets": {
                 "PhaseDay": {
                     "hdr": 1, "iid": 10, "ts": 12345, "seqno": 1, "it": "test",
-                    "pv": 5, "fw": "1.0", "rssi": -30, "data": {"dv": 10}
+                    "pv": 5, "fw": "1.0", "rssi": -30, "data": {"dv": 10, "hwo": 42.5}
                 },
                 "PhaseHour": None,
                 "PhaseMinute": None,
@@ -174,6 +174,7 @@ async def test_get_latest_packets_success():
         assert len(result) == 1
         assert result[0].item_id == 1
         assert result[0].latest_packets.phase_day.hdr == 1
+        assert result[0].latest_packets.phase_day.data.hwo == 42.5
 
 
 #unauthorized

--- a/translations/en.json
+++ b/translations/en.json
@@ -55,6 +55,10 @@
       "power_l3": {
         "name": "Power L3",
         "icon": "mdi:flash"
+      },
+      "energy_export_total": {
+        "name": "Energy Export Total",
+        "icon": "mdi:transmission-tower-export"
       }
     }
   }


### PR DESCRIPTION
Exposes the hwo (high watt-hour out) field from the minute packet as a new TOTAL_INCREASING energy sensor, mirroring the existing energy import sensor which reads hwi.

https://claude.ai/code/session_018nWqghoE5YpXQrkHoSBQCx